### PR TITLE
홈화면과 티클문답 오류 수정

### DIFF
--- a/src/main/java/com/ticle/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/ticle/server/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize ->
-                        authorize.requestMatchers("/users/sign-in", "/users/sign-up", "/swagger-ui/**", "/v3/api-docs/**", "/global/health-check", "/users/**", "/post/**", "/mypage/**").permitAll()
+                        authorize.requestMatchers("/users/sign-in", "/users/sign-up", "/swagger-ui/**", "/v3/api-docs/**", "/global/health-check",
+                                        "/users/**", "/post/**", "/mypage/**", "/opinion/**", "/home/**").permitAll()
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers("/users/**","/mypage/**").hasRole("USER")
                                 .anyRequest().authenticated())

--- a/src/main/java/com/ticle/server/global/dto/PageInfo.java
+++ b/src/main/java/com/ticle/server/global/dto/PageInfo.java
@@ -1,0 +1,19 @@
+package com.ticle.server.global.dto;
+
+import org.springframework.data.domain.Page;
+
+public record PageInfo(
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static PageInfo from(Page<?> page) {
+        return new PageInfo(
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+}

--- a/src/main/java/com/ticle/server/opinion/dto/response/OpinionResponseList.java
+++ b/src/main/java/com/ticle/server/opinion/dto/response/OpinionResponseList.java
@@ -11,7 +11,7 @@ public record OpinionResponseList(
         List<OpinionResponse> opinionResponseList
 ) {
 
-    public static OpinionResponseList from(PageInfo pageInfo, List<OpinionResponse> opinionList) {
+    public static OpinionResponseList of(PageInfo pageInfo, List<OpinionResponse> opinionList) {
         return new OpinionResponseList(pageInfo, opinionList);
     }
 }

--- a/src/main/java/com/ticle/server/opinion/dto/response/OpinionResponseList.java
+++ b/src/main/java/com/ticle/server/opinion/dto/response/OpinionResponseList.java
@@ -1,15 +1,17 @@
 package com.ticle.server.opinion.dto.response;
 
+import com.ticle.server.global.dto.PageInfo;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record OpinionResponseList(
+        PageInfo pageInfo,
         List<OpinionResponse> opinionResponseList
 ) {
 
-    public static OpinionResponseList from(List<OpinionResponse> opinionList) {
-        return new OpinionResponseList(opinionList);
+    public static OpinionResponseList from(PageInfo pageInfo, List<OpinionResponse> opinionList) {
+        return new OpinionResponseList(pageInfo, opinionList);
     }
 }

--- a/src/main/java/com/ticle/server/opinion/service/OpinionService.java
+++ b/src/main/java/com/ticle/server/opinion/service/OpinionService.java
@@ -1,5 +1,6 @@
 package com.ticle.server.opinion.service;
 
+import com.ticle.server.global.dto.PageInfo;
 import com.ticle.server.opinion.domain.Comment;
 import com.ticle.server.opinion.domain.Opinion;
 import com.ticle.server.opinion.domain.type.Order;
@@ -113,11 +114,12 @@ public class OpinionService {
         Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, getOrder(TIME));
 
         Page<Opinion> opinionPage = opinionRepository.findAll(pageable);
+        PageInfo pageInfo = PageInfo.from(opinionPage);
 
         List<OpinionResponse> opinionResponseList = opinionPage.stream()
                 .map(OpinionResponse::from)
                 .toList();
 
-        return OpinionResponseList.from(opinionResponseList);
+        return OpinionResponseList.from(pageInfo, opinionResponseList);
     }
 }

--- a/src/main/java/com/ticle/server/opinion/service/OpinionService.java
+++ b/src/main/java/com/ticle/server/opinion/service/OpinionService.java
@@ -14,6 +14,7 @@ import com.ticle.server.opinion.repository.CommentRepository;
 import com.ticle.server.opinion.repository.HeartRepository;
 import com.ticle.server.opinion.repository.OpinionRepository;
 import com.ticle.server.user.domain.User;
+import com.ticle.server.user.exception.UserNotFoundException;
 import com.ticle.server.user.repository.UserRepository;
 import com.ticle.server.user.service.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ import static com.ticle.server.opinion.domain.type.Order.TIME;
 import static com.ticle.server.opinion.domain.type.Order.getOrder;
 import static com.ticle.server.opinion.exception.errorcode.OpinionErrorCode.COMMENT_NOT_FOUND;
 import static com.ticle.server.opinion.exception.errorcode.OpinionErrorCode.OPINION_NOT_FOUND;
+import static com.ticle.server.user.exception.errorcode.UserErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -48,7 +50,7 @@ public class OpinionService {
     @Transactional
     public void uploadComment(CommentUploadRequest request, Long talkId, CustomUserDetails userId) {
         User user = userRepository.findById(userId.getUserId())
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
         Opinion opinion = opinionRepository.findById(talkId)
                 .orElseThrow(() -> new OpinionNotFoundException(OPINION_NOT_FOUND));
 
@@ -80,8 +82,6 @@ public class OpinionService {
 
     @Transactional
     public List<CommentResponse> getCommentsByOpinion(Long opinionId, CustomUserDetails userDetails, Order orderBy) {
-        User user = userRepository.findById(userDetails.getUserId())
-                .orElseThrow(RuntimeException::new);
         Opinion opinion = opinionRepository.findByOpinionIdWithFetch(opinionId)
                 .orElseThrow(() -> new OpinionNotFoundException(OPINION_NOT_FOUND));
 
@@ -94,8 +94,16 @@ public class OpinionService {
 
         return comments.stream()
                 .map(comment -> {
-                    boolean isHeart = comment.getHearts().stream()
-                            .anyMatch(heart -> heart.getUser().equals(user));
+                    boolean isHeart = false;
+
+                    if (userDetails != null) {
+                        User user = userRepository.findById(userDetails.getUserId())
+                                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
+
+                        isHeart = comment.getHearts().stream()
+                                .anyMatch(heart -> heart.getUser().equals(user));
+                    }
+
                     return CommentResponse.of(comment, isHeart);
                 })
                 .toList();

--- a/src/main/java/com/ticle/server/opinion/service/OpinionService.java
+++ b/src/main/java/com/ticle/server/opinion/service/OpinionService.java
@@ -120,6 +120,6 @@ public class OpinionService {
                 .map(OpinionResponse::from)
                 .toList();
 
-        return OpinionResponseList.from(pageInfo, opinionResponseList);
+        return OpinionResponseList.of(pageInfo, opinionResponseList);
     }
 }

--- a/src/main/java/com/ticle/server/user/exception/errorcode/UserErrorCode.java
+++ b/src/main/java/com/ticle/server/user/exception/errorcode/UserErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "Usere not found"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> 100

## 📝작업 내용

> 1. Home과 Opinion Spring Security에 추가
> 2. 질문 상세 화면에서 로그인하지 않은 유저라면 좋아요가 모두 false로 표시됨
> 3. Page를 return 할때 필요한 정보들만 주기 위해 PageInfo를 만들었습니다!

## 💬리뷰 요구사항(선택)

> 노션에 적어두긴 했는데 로그인 하지 않은 유저가 요청을 보낼 때 "로그인하지 않은 유저입니다"와 같은 Exception이 아니라 500 에러가 뜨는데 이걸 어떻게 해결해야할까요..??